### PR TITLE
ARC-001: Add deterministic quality scripts and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,18 @@ jobs:
         run: pnpm format:check
 
       - name: Lint without warnings
-        run: pnpm lint:ci
+        run: |
+          set -o pipefail
+          pnpm lint:ci 2>&1 | tee lint-output.txt
+
+      - name: Upload lint diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-diagnostics
+          path: lint-output.txt
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Type-check
         run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,7 @@ jobs:
         run: pnpm format:check
 
       - name: Lint without warnings
-        run: |
-          set -o pipefail
-          pnpm lint:ci 2>&1 | tee lint-output.txt
-
-      - name: Upload lint diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-diagnostics
-          path: lint-output.txt
-          if-no-files-found: error
-          retention-days: 1
+        run: pnpm lint:ci
 
       - name: Type-check
         run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run deterministic quality checks
-        run: pnpm check
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Lint without warnings
+        run: pnpm lint:ci
+
+      - name: Type-check
+        run: pnpm typecheck
+
+      - name: Build production application
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Format, lint, types, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install pinned pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run deterministic quality checks
+        run: pnpm check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,16 @@ jobs:
         run: pnpm format:check
 
       - name: Lint without warnings
-        run: pnpm lint:ci
+        run: pnpm lint:ci 2>&1 | tee lint-output.txt
+
+      - name: Upload lint diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-diagnostics
+          path: lint-output.txt
+          if-no-files-found: ignore
+          retention-days: 1
 
       - name: Type-check
         run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,7 @@ jobs:
         run: pnpm format:check
 
       - name: Lint without warnings
-        run: pnpm lint:ci 2>&1 | tee lint-output.txt
-
-      - name: Upload lint diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-diagnostics
-          path: lint-output.txt
-          if-no-files-found: ignore
-          retention-days: 1
+        run: pnpm lint:ci
 
       - name: Type-check
         run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "0.0.1",
   "type": "module",
   "private": true,
+  "packageManager": "pnpm@10.12.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint .",
+    "lint:ci": "eslint . --max-warnings=0",
     "format": "prettier --write \"**/*.{js,mjs,ts,tsx}\"",
+    "format:check": "prettier --check \"**/*.{js,mjs,ts,tsx}\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check": "pnpm format:check && pnpm lint:ci && pnpm typecheck && pnpm build"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",

--- a/src/components/ui/InfiniteMovingCards.tsx
+++ b/src/components/ui/InfiniteMovingCards.tsx
@@ -41,8 +41,7 @@ export default function InfiniteMovingCards({
     "--animation-duration": animationDurationBySpeed[speed],
   }
 
-  const listClassName =
-    "flex shrink-0 flex-nowrap items-center gap-8 py-4"
+  const listClassName = "flex shrink-0 flex-nowrap items-center gap-8 py-4"
 
   return (
     <div

--- a/src/components/ui/InfiniteMovingCards.tsx
+++ b/src/components/ui/InfiniteMovingCards.tsx
@@ -1,8 +1,31 @@
 "use client"
 
+import type { CSSProperties, ReactNode } from "react"
+
 import useTextDirection from "@/hooks/useTextDirection"
 import { cn } from "@/lib/utils"
-import React, { useEffect, useState } from "react"
+
+type InfiniteMovingCardsProps = {
+  children: ReactNode
+  direction?: "left" | "right"
+  speed?: "fast" | "normal" | "slow"
+  pauseOnHover?: boolean
+  className?: string
+}
+
+type ScrollerStyle = CSSProperties & {
+  "--animation-direction": "forwards" | "reverse"
+  "--animation-duration": string
+}
+
+const animationDurationBySpeed: Record<
+  NonNullable<InfiniteMovingCardsProps["speed"]>,
+  string
+> = {
+  fast: "20s",
+  normal: "40s",
+  slow: "80s",
+}
 
 export default function InfiniteMovingCards({
   children,
@@ -10,85 +33,37 @@ export default function InfiniteMovingCards({
   speed = "normal",
   pauseOnHover = true,
   className,
-}: {
-  children: React.ReactNode
-  direction?: "left" | "right"
-  speed?: "fast" | "normal" | "slow"
-  pauseOnHover?: boolean
-  className?: string
-}) {
-  const directionLang = useTextDirection()
-  const containerRef = React.useRef<HTMLDivElement>(null)
-  const scrollerRef = React.useRef<HTMLUListElement>(null)
+}: InfiniteMovingCardsProps) {
+  const textDirection = useTextDirection()
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/immutability
-    addAnimation()
-  }, [])
-  const [start, setStart] = useState(false)
-  function addAnimation() {
-    if (containerRef.current && scrollerRef.current) {
-      const scrollerContent = Array.from(scrollerRef.current.children)
+  const scrollerStyle: ScrollerStyle = {
+    "--animation-direction": direction === "left" ? "forwards" : "reverse",
+    "--animation-duration": animationDurationBySpeed[speed],
+  }
 
-      scrollerContent.forEach((item) => {
-        const duplicatedItem = item.cloneNode(true)
-        if (scrollerRef.current) {
-          scrollerRef.current.appendChild(duplicatedItem)
-        }
-      })
+  const listClassName =
+    "flex shrink-0 flex-nowrap items-center gap-8 py-4"
 
-      getDirection()
-      getSpeed()
-      setStart(true)
-    }
-  }
-  const getDirection = () => {
-    if (containerRef.current) {
-      if (direction === "left") {
-        containerRef.current.style.setProperty(
-          "--animation-direction",
-          "forwards"
-        )
-      } else {
-        containerRef.current.style.setProperty(
-          "--animation-direction",
-          "reverse"
-        )
-      }
-    }
-  }
-  const getSpeed = () => {
-    if (containerRef.current) {
-      if (speed === "fast") {
-        containerRef.current.style.setProperty("--animation-duration", "20s")
-      } else if (speed === "normal") {
-        containerRef.current.style.setProperty("--animation-duration", "40s")
-      } else {
-        containerRef.current.style.setProperty("--animation-duration", "80s")
-      }
-    }
-  }
   return (
     <div
-      ref={containerRef}
       className={cn(
         "scroller relative z-20 m-auto max-w-6xl overflow-hidden [mask-image:linear-gradient(to_right,transparent,white_20%,white_80%,transparent)]",
         className
       )}
+      style={scrollerStyle}
     >
-      <ul
-        ref={scrollerRef}
+      <div
         className={cn(
-          "flex w-max min-w-full shrink-0 flex-nowrap items-center gap-8 py-4",
-          start && directionLang === "rtl"
-            ? "animate-scroll-rtl"
-            : "animate-scroll",
-
+          "flex w-max min-w-full shrink-0 flex-nowrap items-center gap-8",
+          textDirection === "rtl" ? "animate-scroll-rtl" : "animate-scroll",
           pauseOnHover && "hover:[animation-play-state:paused]"
         )}
       >
-        {children}
-      </ul>
+        <ul className={listClassName}>{children}</ul>
+        <ul aria-hidden="true" className={listClassName}>
+          {children}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/src/lib/mdx/get-article.ts
+++ b/src/lib/mdx/get-article.ts
@@ -17,8 +17,6 @@ import {
 
 export type AppLocale = (typeof routing.locales)[number]
 
-type ContentSource = "local" | "remote" | "hybrid"
-
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 const articleFilePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*\.(?:md|mdx)$/

--- a/src/lib/mdx/get-article.ts
+++ b/src/lib/mdx/get-article.ts
@@ -454,6 +454,15 @@ function mergeArticles({
   return Array.from(articlesBySlug.values()).sort(sortArticles)
 }
 
+function createArticleSummary(article: Article): ArticleSummary {
+  return {
+    slug: article.slug,
+    locale: article.locale,
+    source: article.source,
+    metadata: article.metadata,
+  }
+}
+
 async function loadArticles(locale: AppLocale): Promise<ArticleSummary[]> {
   const {
     MDX_CONTENT_SOURCE: contentSource,
@@ -502,7 +511,7 @@ async function loadArticles(locale: AppLocale): Promise<ArticleSummary[]> {
     }
   }
 
-  return articles.map(({ body: _body, ...summary }) => summary)
+  return articles.map(createArticleSummary)
 }
 
 async function loadArticle(


### PR DESCRIPTION
## Ticket

**ARC-001 — Add deterministic quality scripts and GitHub Actions CI**

## Verified problem

The repository had no CI workflow, no `format:check`, `lint:ci`, or aggregate `check` script, and lint warnings did not fail validation. The moving-cards implementation relied on an ESLint suppression around imperative DOM mutation. The article loader also had unused TypeScript bindings that failed warning-free linting.

## Solution

- Pin pnpm through the standard `packageManager` field
- Add `format:check`, `lint:ci`, and aggregate `check` scripts
- Make strict lint fail on any warning with `--max-warnings=0`
- Replace imperative moving-card duplication with declarative React rendering while preserving LTR/RTL animation, speed, direction, and hover-pause behavior
- Replace the unused article-body binding with an explicit typed `ArticleSummary` projection
- Remove the remaining unused `ContentSource` type discovered by strict CI
- Add GitHub Actions CI with frozen-lockfile installation, pnpm-store caching, read-only permissions, and superseded-run cancellation

## Files changed

- `.github/workflows/ci.yml`
- `package.json`
- `src/components/ui/InfiniteMovingCards.tsx`
- `src/lib/mdx/get-article.ts`

## Verification results

GitHub Actions run `29329464619` completed successfully on a clean Ubuntu runner:

- `pnpm install --frozen-lockfile` — passed
- `pnpm format:check` — passed
- `pnpm lint:ci` — passed with zero warnings
- `pnpm typecheck` — passed
- `pnpm build` — passed

The local aggregate command executes the same non-E2E sequence:

```bash
pnpm check
```

which expands to:

```bash
pnpm format:check
pnpm lint:ci
pnpm typecheck
pnpm build
```

The existing Vitest command remains available but is intentionally excluded from ARC-001 CI because the ticket assigns test-framework CI work to ARC-002 and ARC-003.

## Acceptance criteria

- [x] A clean branch passes all CI jobs
- [x] TypeScript diagnostics fail CI through `tsc --noEmit`
- [x] ESLint warnings fail `lint:ci` through `--max-warnings=0`; this was demonstrated when an existing warning failed the workflow before being corrected
- [x] `pnpm build` remains successful
- [x] Local `pnpm check` runs the same non-E2E validations as CI

## Environment and deployment notes

- No new environment variables
- No dependency additions or removals
- No generated artifacts committed
- pnpm pinned to `10.12.1`
- No server secrets or personal information added

## Manual QA still required

- Confirm moving cards animate continuously in both LTR and RTL locales
- Confirm pause-on-hover still works
- Confirm an overlapping newer push cancels an already-running superseded workflow

## Known limitations

The task runner itself could not perform a local clone or package install because GitHub CLI was unavailable and outbound DNS resolution was blocked. Verification was therefore performed by the repository's clean GitHub Actions runner, which passed all ARC-001 validation steps.