### PR TITLE
GH-007: Localize the Contact form completely

### DIFF
--- a/content/dictionaries/contact/de.json
+++ b/content/dictionaries/contact/de.json
@@ -1,0 +1,29 @@
+{
+  "fields": {
+    "name": {
+      "label": "Vollständiger Name",
+      "placeholder": "Max Mustermann"
+    },
+    "email": {
+      "label": "E-Mail-Adresse",
+      "placeholder": "max.mustermann@example.com"
+    },
+    "message": {
+      "label": "Nachricht",
+      "placeholder": "Erzählen Sie mir von Ihrem Projekt, Ihrer Idee oder Ihrer Gelegenheit..."
+    }
+  },
+  "toast": {
+    "success": "Ihre Nachricht wurde erfolgreich gesendet.",
+    "validationError": "Bitte überprüfen Sie die Formularfelder und versuchen Sie es erneut.",
+    "deliveryError": "Ihre Nachricht konnte nicht gesendet werden. Bitte versuchen Sie es in einigen Minuten erneut.",
+    "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut."
+  },
+  "validation": {
+    "nameMin": "Der Name muss mindestens 2 Zeichen lang sein.",
+    "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+    "messageMin": "Die Nachricht muss mindestens 10 Zeichen lang sein.",
+    "messageMax": "Die Nachricht darf höchstens 5000 Zeichen lang sein."
+  },
+  "characterCount": "{current}/{maximum}"
+}

--- a/src/features/contact/contact-form.tsx
+++ b/src/features/contact/contact-form.tsx
@@ -47,20 +47,24 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
   const [announcement, setAnnouncement] =
     useState<SubmissionAnnouncement | null>(null)
 
-  const validationMessages = {
-    nameMin: t("validation.nameMin"),
-    emailInvalid: t("validation.emailInvalid"),
-    messageMin: t("validation.messageMin"),
-    messageMax: t("validation.messageMax"),
-  }
+  const nameMinMessage = t("validation.nameMin")
+  const emailInvalidMessage = t("validation.emailInvalid")
+  const messageMinMessage = t("validation.messageMin")
+  const messageMaxMessage = t("validation.messageMax")
 
   const localizedSchema = useMemo(
-    () => createContactFormSchema(validationMessages),
+    () =>
+      createContactFormSchema({
+        nameMin: nameMinMessage,
+        emailInvalid: emailInvalidMessage,
+        messageMin: messageMinMessage,
+        messageMax: messageMaxMessage,
+      }),
     [
-      validationMessages.emailInvalid,
-      validationMessages.messageMax,
-      validationMessages.messageMin,
-      validationMessages.nameMin,
+      emailInvalidMessage,
+      messageMaxMessage,
+      messageMinMessage,
+      nameMinMessage,
     ]
   )
 
@@ -79,13 +83,13 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
   ): string {
     switch (field) {
       case "name":
-        return validationMessages.nameMin
+        return nameMinMessage
       case "email":
-        return validationMessages.emailInvalid
+        return emailInvalidMessage
       case "message":
         return codes.includes("TOO_LONG")
-          ? validationMessages.messageMax
-          : validationMessages.messageMin
+          ? messageMaxMessage
+          : messageMinMessage
       default: {
         const exhaustiveCheck: never = field
         return exhaustiveCheck

--- a/src/features/contact/contact-form.tsx
+++ b/src/features/contact/contact-form.tsx
@@ -60,12 +60,7 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
         messageMin: messageMinMessage,
         messageMax: messageMaxMessage,
       }),
-    [
-      emailInvalidMessage,
-      messageMaxMessage,
-      messageMinMessage,
-      nameMinMessage,
-    ]
+    [emailInvalidMessage, messageMaxMessage, messageMinMessage, nameMinMessage]
   )
 
   const form = useForm<ContactFormType>({

--- a/src/features/contact/contact-form.tsx
+++ b/src/features/contact/contact-form.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslations } from "next-intl"
+import { useMemo, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { toast } from "sonner"
 
@@ -21,10 +22,11 @@ import {
 import {
   type ContactField,
   type ContactFieldErrors,
+  type ContactValidationErrorCode,
   type SubmitContactFormResult,
 } from "@/features/contact/contact-result"
 import {
-  contactFormSchema,
+  createContactFormSchema,
   type ContactFormType,
 } from "@/features/contact/contact-schema"
 import { submitContactForm } from "@/features/contact/server/submit-contact-form"
@@ -33,13 +35,37 @@ type ContactFormProps = {
   onSuccess?: () => void
 }
 
+type SubmissionAnnouncement = {
+  kind: "success" | "error"
+  message: string
+}
+
 const contactFields: ContactField[] = ["name", "email", "message"]
 
 export function ContactForm({ onSuccess }: ContactFormProps) {
   const t = useTranslations("contact.form")
+  const [announcement, setAnnouncement] =
+    useState<SubmissionAnnouncement | null>(null)
+
+  const validationMessages = {
+    nameMin: t("validation.nameMin"),
+    emailInvalid: t("validation.emailInvalid"),
+    messageMin: t("validation.messageMin"),
+    messageMax: t("validation.messageMax"),
+  }
+
+  const localizedSchema = useMemo(
+    () => createContactFormSchema(validationMessages),
+    [
+      validationMessages.emailInvalid,
+      validationMessages.messageMax,
+      validationMessages.messageMin,
+      validationMessages.nameMin,
+    ]
+  )
 
   const form = useForm<ContactFormType>({
-    resolver: zodResolver(contactFormSchema),
+    resolver: zodResolver(localizedSchema),
     defaultValues: {
       name: "",
       email: "",
@@ -47,38 +73,76 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
     },
   })
 
+  function getServerFieldErrorMessage(
+    field: ContactField,
+    codes: ContactValidationErrorCode[]
+  ): string {
+    switch (field) {
+      case "name":
+        return validationMessages.nameMin
+      case "email":
+        return validationMessages.emailInvalid
+      case "message":
+        return codes.includes("TOO_LONG")
+          ? validationMessages.messageMax
+          : validationMessages.messageMin
+      default: {
+        const exhaustiveCheck: never = field
+        return exhaustiveCheck
+      }
+    }
+  }
+
   function applyServerFieldErrors(fieldErrors: ContactFieldErrors): void {
+    let firstInvalidField: ContactField | undefined
+
     for (const field of contactFields) {
-      if (!fieldErrors[field]?.length) {
+      const codes = fieldErrors[field]
+
+      if (!codes?.length) {
         continue
       }
 
+      firstInvalidField ??= field
       form.setError(field, {
         type: "server",
-        message: t("toast.validationError"),
+        message: getServerFieldErrorMessage(field, codes),
       })
     }
+
+    if (firstInvalidField) {
+      form.setFocus(firstInvalidField)
+    }
+  }
+
+  function announceError(message: string): void {
+    setAnnouncement({ kind: "error", message })
+    toast.error(message)
   }
 
   function handleSubmissionResult(result: SubmitContactFormResult): void {
     switch (result.status) {
-      case "success":
-        toast.success(t("toast.success"))
+      case "success": {
+        const message = t("toast.success")
+
+        setAnnouncement({ kind: "success", message })
+        toast.success(message)
         form.reset()
         onSuccess?.()
         return
+      }
 
       case "validation_error":
         applyServerFieldErrors(result.fieldErrors)
-        toast.error(t("toast.validationError"))
+        announceError(t("toast.validationError"))
         return
 
       case "delivery_error":
-        toast.error(t("toast.deliveryError"))
+        announceError(t("toast.deliveryError"))
         return
 
       case "unexpected_error":
-        toast.error(t("toast.unexpectedError"))
+        announceError(t("toast.unexpectedError"))
         return
 
       default: {
@@ -89,17 +153,23 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
   }
 
   async function onSubmit(data: ContactFormType) {
+    setAnnouncement(null)
+
     try {
       const result = await submitContactForm(data)
       handleSubmissionResult(result)
     } catch {
-      toast.error(t("toast.unexpectedError"))
+      announceError(t("toast.unexpectedError"))
     }
   }
 
   return (
     <div className="w-full">
-      <form id="contact-form" onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        id="contact-form"
+        noValidate
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
         <FieldGroup>
           <Controller
             name="name"
@@ -180,6 +250,17 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
             )}
           />
         </FieldGroup>
+
+        {announcement && (
+          <p
+            className="sr-only"
+            role={announcement.kind === "error" ? "alert" : "status"}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {announcement.message}
+          </p>
+        )}
       </form>
     </div>
   )

--- a/src/features/contact/contact-form.tsx
+++ b/src/features/contact/contact-form.tsx
@@ -165,11 +165,7 @@ export function ContactForm({ onSuccess }: ContactFormProps) {
 
   return (
     <div className="w-full">
-      <form
-        id="contact-form"
-        noValidate
-        onSubmit={form.handleSubmit(onSubmit)}
-      >
+      <form id="contact-form" noValidate onSubmit={form.handleSubmit(onSubmit)}>
         <FieldGroup>
           <Controller
             name="name"

--- a/src/features/contact/contact-schema.test.ts
+++ b/src/features/contact/contact-schema.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { contactFormSchema } from "@/features/contact/contact-schema"
+import {
+  contactFormSchema,
+  createContactFormSchema,
+} from "@/features/contact/contact-schema"
 
 const validContactInput = {
   name: "Test User",
@@ -71,5 +74,41 @@ describe("contactFormSchema", () => {
         message: [],
       }).success
     ).toBe(false)
+  })
+
+  it("creates independent localized schemas", () => {
+    const englishSchema = createContactFormSchema({
+      nameMin: "Name must be at least 2 characters.",
+      emailInvalid: "Please enter a valid email address.",
+      messageMin: "Message must be at least 10 characters.",
+      messageMax: "Message must be less than 5000 characters.",
+    })
+    const germanSchema = createContactFormSchema({
+      nameMin: "Der Name muss mindestens 2 Zeichen lang sein.",
+      emailInvalid: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+      messageMin: "Die Nachricht muss mindestens 10 Zeichen lang sein.",
+      messageMax: "Die Nachricht darf höchstens 5000 Zeichen lang sein.",
+    })
+
+    const englishResult = englishSchema.safeParse({
+      ...validContactInput,
+      name: "A",
+    })
+    const germanResult = germanSchema.safeParse({
+      ...validContactInput,
+      name: "A",
+    })
+
+    expect(englishResult.success).toBe(false)
+    expect(germanResult.success).toBe(false)
+
+    if (!englishResult.success && !germanResult.success) {
+      expect(englishResult.error.issues[0]?.message).toBe(
+        "Name must be at least 2 characters."
+      )
+      expect(germanResult.error.issues[0]?.message).toBe(
+        "Der Name muss mindestens 2 Zeichen lang sein."
+      )
+    }
   })
 })

--- a/src/features/contact/contact-schema.ts
+++ b/src/features/contact/contact-schema.ts
@@ -7,9 +7,7 @@ export type ContactValidationMessages = {
   messageMax: string
 }
 
-export function createContactFormSchema(
-  messages: ContactValidationMessages
-) {
+export function createContactFormSchema(messages: ContactValidationMessages) {
   return z.object({
     name: z.string().trim().min(2, messages.nameMin),
     email: z.string().trim().email(messages.emailInvalid),

--- a/src/features/contact/contact-schema.ts
+++ b/src/features/contact/contact-schema.ts
@@ -1,13 +1,35 @@
 import { z } from "zod"
 
-export const contactFormSchema = z.object({
-  name: z.string().trim().min(2, "Name must be at least 2 characters"),
-  email: z.string().trim().email("Please enter a valid email address"),
-  message: z
-    .string()
-    .trim()
-    .min(10, "Message must be at least 10 characters")
-    .max(5000, "Message must be less than 5000 characters"),
-})
+export type ContactValidationMessages = {
+  nameMin: string
+  emailInvalid: string
+  messageMin: string
+  messageMax: string
+}
+
+export function createContactFormSchema(
+  messages: ContactValidationMessages
+) {
+  return z.object({
+    name: z.string().trim().min(2, messages.nameMin),
+    email: z.string().trim().email(messages.emailInvalid),
+    message: z
+      .string()
+      .trim()
+      .min(10, messages.messageMin)
+      .max(5000, messages.messageMax),
+  })
+}
+
+const serverValidationMessages: ContactValidationMessages = {
+  nameMin: "NAME_TOO_SHORT",
+  emailInvalid: "EMAIL_INVALID",
+  messageMin: "MESSAGE_TOO_SHORT",
+  messageMax: "MESSAGE_TOO_LONG",
+}
+
+export const contactFormSchema = createContactFormSchema(
+  serverValidationMessages
+)
 
 export type ContactFormType = z.infer<typeof contactFormSchema>

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -5,9 +5,8 @@ import { defaultLocale, isAppLocale } from "@/i18n/locale"
 export default getRequestConfig(async ({ requestLocale }) => {
   const requestedLocale = await requestLocale
   const locale = isAppLocale(requestedLocale) ? requestedLocale : defaultLocale
-  const messages = (
-    await import(`../../content/dictionaries/${locale}.json`)
-  ).default
+  const messages = (await import(`../../content/dictionaries/${locale}.json`))
+    .default
 
   if (locale === "de") {
     const contactForm = (

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -5,10 +5,29 @@ import { defaultLocale, isAppLocale } from "@/i18n/locale"
 export default getRequestConfig(async ({ requestLocale }) => {
   const requestedLocale = await requestLocale
   const locale = isAppLocale(requestedLocale) ? requestedLocale : defaultLocale
+  const messages = (
+    await import(`../../content/dictionaries/${locale}.json`)
+  ).default
+
+  if (locale === "de") {
+    const contactForm = (
+      await import("../../content/dictionaries/contact/de.json")
+    ).default
+
+    return {
+      locale,
+      messages: {
+        ...messages,
+        contact: {
+          ...messages.contact,
+          form: contactForm,
+        },
+      },
+    }
+  }
 
   return {
     locale,
-    messages: (await import(`../../content/dictionaries/${locale}.json`))
-      .default,
+    messages,
   }
 })

--- a/tests/e2e/contact-dialog.spec.ts
+++ b/tests/e2e/contact-dialog.spec.ts
@@ -36,6 +36,9 @@ test.describe("Contact dialog", () => {
       "aria-invalid",
       "true"
     )
+    await expect(
+      page.getByText("Name must be at least 2 characters.")
+    ).toBeVisible()
 
     await page.locator("#contact-name").fill("Test User")
     await page.locator("#contact-email").fill("test.user@example.test")
@@ -45,5 +48,36 @@ test.describe("Contact dialog", () => {
     await submit.click()
 
     await expect(page.getByRole("dialog")).toBeHidden()
+  })
+
+  test("localizes German fields and client validation messages", async ({
+    page,
+  }) => {
+    await page.goto("/de/contact")
+
+    await expect(page.getByLabel("Vollständiger Name")).toHaveAttribute(
+      "placeholder",
+      "Max Mustermann"
+    )
+    await expect(page.getByLabel("E-Mail-Adresse")).toHaveAttribute(
+      "placeholder",
+      "max.mustermann@example.com"
+    )
+    await expect(page.getByLabel("Nachricht")).toHaveAttribute(
+      "placeholder",
+      "Erzählen Sie mir von Ihrem Projekt, Ihrer Idee oder Ihrer Gelegenheit..."
+    )
+
+    await page.locator('button[form="contact-form"]').click()
+
+    await expect(
+      page.getByText("Der Name muss mindestens 2 Zeichen lang sein.")
+    ).toBeVisible()
+    await expect(
+      page.getByText("Bitte geben Sie eine gültige E-Mail-Adresse ein.")
+    ).toBeVisible()
+    await expect(
+      page.getByText("Die Nachricht muss mindestens 10 Zeichen lang sein.")
+    ).toBeVisible()
   })
 })


### PR DESCRIPTION
## Ticket

**GH-007 — Localize the Contact form completely**

## Verified problem

The Contact feature had already moved under `src/features/contact`, but its client resolver still used a global schema containing hard-coded English messages. The German base dictionary also contained English labels, placeholders, validation messages, and malformed success/failure copy. ARC-018 server validation codes were mapped to one generic field error rather than localized field-specific feedback.

## Solution

- Add an immutable Contact schema factory that receives locale-specific validation messages.
- Keep the exported server schema authoritative and locale-neutral.
- Build the client resolver from the active next-intl messages without mutable global schema state.
- Map typed server validation codes to safe localized field messages.
- Preserve entered values for validation, delivery, and unexpected failures; reset only after confirmed success.
- Add an accessible live announcement region while retaining Sonner feedback.
- Add a focused German Contact dictionary override loaded by the next-intl request boundary.
- Add unit coverage for independent localized schemas and Playwright coverage for German field copy and validation.

## Files changed

- Added `content/dictionaries/contact/de.json`
- Updated `src/features/contact/contact-form.tsx`
- Updated `src/features/contact/contact-schema.ts`
- Updated `src/features/contact/contact-schema.test.ts`
- Updated `src/i18n/request.ts`
- Updated `tests/e2e/contact-dialog.spec.ts`

## Verification

The implementation environment could not resolve `github.com`, so a local clone and local pnpm execution were unavailable. The branch starts exactly from current `main` (`9aa59a1`), is not behind, and the changed-file set is limited to GH-007 scope. GitHub Actions is the executable verification source for:

```bash
pnpm format:check
pnpm lint
pnpm typecheck
pnpm test
pnpm build
pnpm vitest run src/features/contact/contact-schema.test.ts
pnpm vitest run src/features/contact/server/submit-contact-form.test.ts
pnpm test:e2e --project=desktop-chromium tests/e2e/contact-dialog.spec.ts
pnpm test:e2e --project=mobile-chromium tests/e2e/contact-dialog.spec.ts
```

## Acceptance criteria

- [x] Every visible Contact form string matches the active English or German locale.
- [x] Client validation messages are localized in English and German.
- [x] Server failures map to safe localized user messages.
- [x] Failed submissions preserve entered values.
- [x] Success and error feedback use accessible announcement mechanisms.

## Environment and deployment notes

- No packages added or removed.
- No environment variables added or changed.
- No Telegram transport behavior changed.
- No secret values, visitor PII, server exception details, or technical logs were localized or exposed.

## Manual QA still required

- Trigger each client validation state in `/en/contact` and `/de/contact`.
- Verify server validation, delivery failure, and unexpected failure retain values and announce localized feedback.
- Verify successful dialog submission resets the form, closes the dialog, and announces the localized toast.
- Review the German wording in the browser at desktop and mobile widths.

## Known limitations

Pending-state and touch-layout improvements remain intentionally outside this ticket and are owned by GH-015.