### PR TITLE
GH-003: Connect Home projects to published case studies

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -266,9 +266,7 @@ export default async function HomePage({ params }: HomePageProps) {
 
         <CoreExpertise />
 
-        <SelectedProjects
-          slugs={["ai-agent-platform", "scalable-backend-platform"]}
-        />
+        <SelectedProjects />
 
         <ArchitectureShowcase />
 

--- a/src/components/selectedProjects/SelectedProjects.tsx
+++ b/src/components/selectedProjects/SelectedProjects.tsx
@@ -2,56 +2,25 @@ import { ArrowRight } from "lucide-react"
 import { getLocale, getTranslations } from "next-intl/server"
 
 import { Link } from "@/i18n/routing"
-import { getArticle, type AppLocale } from "@/lib/mdx/get-article"
+import { getArticles, type AppLocale } from "@/lib/mdx/get-article"
+import { selectFeaturedArticles } from "@/lib/mdx/select-featured-articles"
 
 import { Alert } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 
-type SelectedProjectsProps = {
-  /**
-   * Article slugs in the order they should appear.
-   *
-   * Example:
-   * [
-   *   "ai-agent-platform",
-   *   "scalable-backend-platform",
-   * ]
-   */
-  slugs: readonly string[]
-}
-
-export default async function SelectedProjects({
-  slugs,
-}: SelectedProjectsProps) {
+export default async function SelectedProjects() {
   const locale = (await getLocale()) as AppLocale
 
-  const t = await getTranslations({
-    locale,
-    namespace: "home.selectedProjects",
-  })
+  const [t, articles] = await Promise.all([
+    getTranslations({
+      locale,
+      namespace: "home.selectedProjects",
+    }),
+    getArticles(locale),
+  ])
 
-  const articles = await Promise.all(
-    slugs.map(async (slug) => {
-      const article = await getArticle(locale, slug)
-
-      if (!article) {
-        if (process.env.NODE_ENV !== "production") {
-          console.warn(
-            `[SelectedProjects] Article not found: "${locale}/${slug}"`
-          )
-        }
-
-        return null
-      }
-
-      return article
-    })
-  )
-
-  const selectedArticles = articles.filter(
-    (article): article is NonNullable<typeof article> => article !== null
-  )
+  const selectedArticles = selectFeaturedArticles(articles)
 
   if (selectedArticles.length === 0) {
     return null
@@ -84,7 +53,6 @@ export default async function SelectedProjects({
         <div className="mt-12 space-y-8">
           {selectedArticles.map((article) => {
             const { slug, metadata } = article
-
             const articleHref = `/articles/${slug}` as const
             const challenge = metadata.challenge ?? metadata.description
 

--- a/src/lib/mdx/select-featured-articles.test.ts
+++ b/src/lib/mdx/select-featured-articles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import type { ArticleSummary } from "@/lib/mdx/article-schema"
+import { selectFeaturedArticles } from "@/lib/mdx/select-featured-articles"
+
+function createArticle(
+  slug: string,
+  options: {
+    featured?: boolean
+    order?: number
+  } = {}
+): ArticleSummary {
+  return {
+    slug,
+    locale: "en",
+    source: "local",
+    metadata: {
+      title: slug,
+      description: `${slug} description`,
+      category: "Case Study",
+      status: "Case Study",
+      publishedAt: "2026-07-01",
+      coverImage: `/articles/${slug}/cover.png`,
+      coverImageAlt: `${slug} cover`,
+      tags: [],
+      stack: [],
+      icon: "code",
+      featured: options.featured ?? false,
+      order: options.order,
+      draft: false,
+    },
+  }
+}
+
+describe("selectFeaturedArticles", () => {
+  it("selects articles explicitly featured or ordered for the Home page", () => {
+    const featured = createArticle("featured", { featured: true })
+    const ordered = createArticle("ordered", { order: 2 })
+    const archiveOnly = createArticle("archive-only")
+
+    expect(
+      selectFeaturedArticles([featured, ordered, archiveOnly]).map(
+        ({ slug }) => slug
+      )
+    ).toEqual(["featured", "ordered"])
+  })
+
+  it("preserves the article loader order", () => {
+    const first = createArticle("first", { order: 1 })
+    const second = createArticle("second", { order: 2 })
+
+    expect(selectFeaturedArticles([first, second])).toEqual([first, second])
+  })
+
+  it("returns an empty collection when no article is selected", () => {
+    expect(selectFeaturedArticles([createArticle("archive-only")])).toEqual([])
+  })
+})

--- a/src/lib/mdx/select-featured-articles.ts
+++ b/src/lib/mdx/select-featured-articles.ts
@@ -1,0 +1,17 @@
+import type { ArticleSummary } from "@/lib/mdx/article-schema"
+
+/**
+ * Selects published article summaries that are intended for the Home page.
+ *
+ * `getArticles()` already removes production drafts and sorts articles by
+ * featured state, explicit order, publication date, and title. An explicit
+ * order remains a supported opt-in for existing case studies while new
+ * content can use the preferred `featured: true` frontmatter field.
+ */
+export function selectFeaturedArticles(
+  articles: readonly ArticleSummary[]
+): ArticleSummary[] {
+  return articles.filter(
+    ({ metadata }) => metadata.featured || metadata.order !== undefined
+  )
+}


### PR DESCRIPTION
## Ticket

**GH-003 — Connect Home projects to real published case studies**

## Verified problem

The Home page passed a hard-coded list of article slugs to `SelectedProjects`. Although the cards already read article metadata, adding, removing, renaming, or unpublishing a case study could leave stale Home configuration in `src/app/[locale]/page.tsx`.

## Solution

- Load the localized article collection through `getArticles(locale)`.
- Select Home projects from article frontmatter using `featured: true` or an explicit `order`.
- Preserve the ordering produced by the article loader.
- Remove the hard-coded slug list from the Home page.
- Keep title, description, category, status, stack, challenge, and link destinations sourced from the same article metadata.
- Add unit coverage for selection, exclusion, empty results, and order preservation.

## Files changed

- `src/app/[locale]/page.tsx`
- `src/components/selectedProjects/SelectedProjects.tsx`
- `src/lib/mdx/select-featured-articles.ts`
- `src/lib/mdx/select-featured-articles.test.ts`

## Verification

A ready-for-review PR is used so the repository CI runs:

- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm build`

Local execution was not available in the connector environment because the shell could not resolve `github.com`; CI is the authoritative verification environment for this branch.

## Acceptance criteria

- [x] Every Home project links to the matching localized article route.
- [x] Home projects are derived only from articles returned by the article loader.
- [x] Card title, description, stack, and category come from article metadata.
- [x] Adding, removing, or unpublishing selected content no longer requires updating a slug list in the Home page.

## Environment and deployment

- No package changes.
- No environment-variable changes.
- No deployment configuration changes.

## Manual QA after CI

- Verify project CTAs on `/en` and `/de`.
- Verify keyboard focus and Enter activation.
- Confirm a production draft or article without `featured`/`order` does not appear on Home.

## Known limitations

Article selection assumes `getArticles()` remains the publication boundary and ordering source, which matches the current MDX architecture.