### PR TITLE
fix: correct FinalCTA semantics and styling

### DIFF
--- a/src/components/finalCTA/FinalCTA.tsx
+++ b/src/components/finalCTA/FinalCTA.tsx
@@ -2,8 +2,6 @@ import { useTranslations } from "next-intl"
 
 import { ContactDialog } from "@/features/contact/contact-dialog"
 
-import { Alert } from "../ui/alert"
-
 export default function FinalCTA() {
   const t = useTranslations("home.finalCTA")
 
@@ -11,9 +9,11 @@ export default function FinalCTA() {
     <section
       className="min-w-0 px-2 py-12 sm:px-0 lg:py-24"
       data-testid="final-cta"
+      aria-labelledby="final-cta-heading"
     >
-      <Alert className="mx-auto max-w-5xl min-w-0 bg-muted-foreground/1 px-2 py-8 text-center sm:p-12 lg:px-0">
+      <div className="mx-auto max-w-5xl min-w-0 rounded-lg border border-border bg-muted px-2 py-8 text-center text-foreground sm:p-12 lg:px-0">
         <h2
+          id="final-cta-heading"
           className="min-w-0 text-4xl font-semibold tracking-tight [overflow-wrap:anywhere] break-words sm:text-5xl"
           data-testid="final-cta-heading"
         >
@@ -31,7 +31,7 @@ export default function FinalCTA() {
         >
           <ContactDialog />
         </div>
-      </Alert>
+      </div>
     </section>
   )
 }

--- a/tests/e2e/final-cta.spec.ts
+++ b/tests/e2e/final-cta.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Final CTA semantics and styling", () => {
+  test("is a labelled section without an assertive live region", async ({
+    page,
+  }) => {
+    await page.goto("/en")
+
+    const cta = page.getByTestId("final-cta")
+    await expect(cta).toHaveRole("region")
+    await expect(cta.getByRole("alert")).toHaveCount(0)
+    await expect(cta.locator('[aria-live="assertive"]')).toHaveCount(0)
+
+    const headingId = await page
+      .getByTestId("final-cta-heading")
+      .getAttribute("id")
+    expect(headingId).toBeTruthy()
+    await expect(cta).toHaveAttribute("aria-labelledby", headingId ?? "")
+  })
+
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`background is visibly distinguishable from the page in ${colorScheme} mode`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme })
+      await page.addInitScript(
+        (scheme) => localStorage.setItem("theme", scheme),
+        colorScheme
+      )
+      await page.goto("/en")
+
+      await expect(page.locator("html")).toHaveClass(
+        colorScheme === "dark" ? /dark/ : /light/
+      )
+
+      const cta = page.getByTestId("final-cta")
+      const wrapper = cta.locator(":scope > div").first()
+
+      const wrapperStyles = await wrapper.evaluate((el) => {
+        const style = getComputedStyle(el)
+
+        return {
+          background: style.backgroundColor,
+          borderTopColor: style.borderTopColor,
+          borderTopWidth: style.borderTopWidth,
+        }
+      })
+      const pageBackground = await page
+        .locator("body")
+        .evaluate((el) => getComputedStyle(el).backgroundColor)
+
+      expect(wrapperStyles.background).not.toBe(pageBackground)
+      expect(wrapperStyles.background).not.toBe("rgba(0, 0, 0, 0)")
+      expect(wrapperStyles.borderTopColor).not.toBe("rgba(0, 0, 0, 0)")
+      expect(wrapperStyles.borderTopWidth).not.toBe("0px")
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- replace the FinalCTA `Alert` wrapper with a neutral semantic container
- label the CTA section through its existing heading
- use visible design-system border, background, and foreground tokens
- add focused Playwright coverage for semantics and light/dark background contrast

## Accessibility

- removes `role="alert"` from normal marketing content
- adds `aria-labelledby="final-cta-heading"` to the section
- preserves the existing ContactDialog and responsive layout behavior

## Testing

- `pnpm exec playwright test tests/e2e/final-cta.spec.ts --list` — 6 cases discovered across desktop/mobile Chromium
- `pnpm check` — passed
  - formatting
  - ESLint
  - dead-code detection
  - TypeScript
  - 191 Vitest tests
  - localized content validation
  - production build
- semantic regression and security scans — passed

The local environment did not have a Playwright browser binary, so the focused browser test is verified by the PR's Playwright CI job.

Closes #47
