### PR TITLE
fix: standardize responsive gutters and container widths

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -196,7 +196,10 @@ export default async function AboutPage({ params }: AboutPageProps) {
 
       <main className="min-h-screen">
         <section className="py-12 lg:py-24">
-          <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[0.8fr_1.2fr]">
+          <div
+            className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.8fr_1.2fr]"
+            data-layout-container="about-intro"
+          >
             <div>
               <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
                 {intro("eyebrow")}
@@ -216,7 +219,10 @@ export default async function AboutPage({ params }: AboutPageProps) {
         </section>
 
         <section className="border-y border-border bg-foreground/2 py-12 lg:py-24">
-          <div className="mx-auto max-w-7xl px-6">
+          <div
+            className="mx-auto max-w-6xl px-4 sm:px-6"
+            data-layout-container="about-journey"
+          >
             <div className="max-w-3xl">
               <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
                 {journey("eyebrow")}

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -250,7 +250,10 @@ export default async function ArticlesPage({ params }: ArticlesPageProps) {
           aria-labelledby="engineering-heading"
           className="py-16 lg:py-24"
         >
-          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div
+            className="mx-auto max-w-6xl px-4 sm:px-6"
+            data-layout-container="articles"
+          >
             <header className="max-w-3xl">
               <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
                 {content("eyebrow")}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -147,7 +147,10 @@ export default async function ContactPage({ params }: ContactPageProps) {
         }}
       />
 
-      <main className="relative min-h-screen overflow-x-clip px-4 sm:px-6 lg:px-0">
+      <main
+        className="relative min-h-screen overflow-x-clip px-4 sm:px-6"
+        data-layout-container="contact"
+      >
         <div className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-3xl min-w-0 flex-col justify-center gap-10 py-16 md:gap-14 lg:py-24">
           <header className="w-full min-w-0">
             <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">

--- a/src/components/architectureShowcase/ArchitectureShowcase.tsx
+++ b/src/components/architectureShowcase/ArchitectureShowcase.tsx
@@ -45,7 +45,10 @@ export default function ArchitectureShowcase() {
 
   return (
     <section className="border-y bg-foreground/2 py-12 lg:py-24">
-      <div className="mx-auto grid max-w-6xl gap-12 px-2 lg:grid-cols-2 lg:items-center lg:px-0">
+      <div
+        className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center"
+        data-layout-container="architecture-showcase"
+      >
         <div>
           <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
             {t("eyebrow")}

--- a/src/components/coreExpertise/CoreExpertise.tsx
+++ b/src/components/coreExpertise/CoreExpertise.tsx
@@ -29,7 +29,10 @@ export default function CoreExpertise() {
 
   return (
     <section className="border-y bg-foreground/2 py-12 lg:py-24">
-      <div className="mx-auto max-w-6xl px-2 lg:px-0">
+      <div
+        className="mx-auto max-w-6xl px-4 sm:px-6"
+        data-layout-container="core-expertise"
+      >
         <div className="max-w-3xl">
           <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
             {t("eyebrow")}

--- a/src/components/engineeringBeyondCode/EngineeringBeyondCode.tsx
+++ b/src/components/engineeringBeyondCode/EngineeringBeyondCode.tsx
@@ -15,7 +15,10 @@ export default function EngineeringBeyondCode() {
 
   return (
     <section className="relative py-12 lg:py-24">
-      <div className="mx-auto grid max-w-6xl gap-12 px-2 lg:grid-cols-2 lg:items-center lg:px-0">
+      <div
+        className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center"
+        data-layout-container="engineering-beyond-code"
+      >
         <div>
           <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
             {t("eyebrow")}

--- a/src/components/finalCTA/FinalCTA.tsx
+++ b/src/components/finalCTA/FinalCTA.tsx
@@ -7,11 +7,14 @@ export default function FinalCTA() {
 
   return (
     <section
-      className="min-w-0 px-2 py-12 sm:px-0 lg:py-24"
+      className="min-w-0 px-4 py-12 sm:px-6 lg:py-24"
       data-testid="final-cta"
       aria-labelledby="final-cta-heading"
     >
-      <div className="mx-auto max-w-5xl min-w-0 rounded-lg border border-border bg-muted px-2 py-8 text-center text-foreground sm:p-12 lg:px-0">
+      <div
+        className="mx-auto max-w-6xl min-w-0 rounded-lg border border-border bg-muted p-6 text-center text-foreground sm:p-12"
+        data-layout-container="final-cta"
+      >
         <h2
           id="final-cta-heading"
           className="min-w-0 text-4xl font-semibold tracking-tight [overflow-wrap:anywhere] break-words sm:text-5xl"

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -28,10 +28,13 @@ export default function Footer() {
   }))
 
   return (
-    <footer className="relative border-t bg-background px-2 py-8">
+    <footer className="relative border-t bg-background py-8">
       <GridBackground />
 
-      <div className="relative mx-auto flex max-w-6xl flex-col-reverse items-center justify-between gap-8 lg:flex-row">
+      <div
+        className="relative mx-auto flex max-w-6xl flex-col-reverse items-center justify-between gap-8 px-4 sm:px-6 lg:flex-row"
+        data-layout-container="footer"
+      >
         <div>
           <div className="flex justify-center md:justify-start">
             <Link

--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -20,11 +20,11 @@ export default function Hero() {
   const infiniteMovingCards = t.raw("hero.infiniteMovingCards") as string[]
 
   return (
-    <div
-      className="relative overflow-x-clip px-2 lg:mb-24 lg:px-0"
-      data-testid="hero"
-    >
-      <div className="relative m-auto flex h-full max-w-6xl flex-col pt-12 md:mt-0 lg:flex-row">
+    <div className="relative overflow-x-clip lg:mb-24" data-testid="hero">
+      <div
+        className="relative m-auto flex h-full max-w-6xl flex-col px-4 pt-12 sm:px-6 md:mt-0 lg:flex-row"
+        data-layout-container="hero-primary"
+      >
         <div className="flex w-full flex-col justify-end gap-4 sm:gap-6 lg:gap-10 lg:pt-0">
           <TechBadge />
 
@@ -105,7 +105,10 @@ export default function Hero() {
         </div>
       </div>
 
-      <div className="relative m-auto max-w-6xl items-end justify-between lg:flex">
+      <div
+        className="relative m-auto max-w-6xl items-end justify-between px-4 sm:px-6 lg:flex"
+        data-layout-container="hero-metrics"
+      >
         <div className="min-w-0 lg:w-[59%]">
           <ul
             className="grid w-full grid-cols-2 gap-x-4 gap-y-2 bg-background/10 py-4 text-center text-sm leading-6 text-muted-foreground backdrop-blur-xs sm:grid-cols-4 sm:text-base lg:flex lg:flex-wrap lg:text-lg lg:leading-8"

--- a/src/components/selectedProjects/SelectedProjects.tsx
+++ b/src/components/selectedProjects/SelectedProjects.tsx
@@ -32,7 +32,10 @@ export default async function SelectedProjects() {
       aria-labelledby="selected-projects-heading"
       className="relative border-y py-12 lg:py-24"
     >
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+      <div
+        className="mx-auto max-w-6xl px-4 sm:px-6"
+        data-layout-container="selected-projects"
+      >
         <header className="max-w-3xl">
           <p className="mb-3 text-sm font-medium tracking-widest text-accent-foreground uppercase">
             {t("eyebrow")}

--- a/src/components/technologies/Technologies.tsx
+++ b/src/components/technologies/Technologies.tsx
@@ -29,8 +29,11 @@ export default function Technologies() {
   const t = useTranslations("home.technologies")
 
   return (
-    <section className="relative lg:px-0">
-      <div className="relative m-auto flex h-full max-w-6xl flex-col gap-8 px-2 py-8 lg:gap-16 lg:px-0 lg:py-24">
+    <section className="relative">
+      <div
+        className="relative m-auto flex h-full max-w-6xl flex-col gap-8 px-4 py-8 sm:px-6 lg:gap-16 lg:py-24"
+        data-layout-container="technologies"
+      >
         <div className="flex flex-col gap-2 lg:gap-4">
           <h2 className="text-4xl font-semibold tracking-tight sm:text-5xl">
             {t("title")}

--- a/src/styles/layout-gutters.test.ts
+++ b/src/styles/layout-gutters.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+type Case = {
+  file: string
+  description: string
+  forbidden: string
+  required: string
+}
+
+// Canonical rule (issue #48): section gutters use `px-4 sm:px-6` on the
+// element that owns the horizontal inset, and primary containers use
+// `mx-auto max-w-6xl`, matching the reference implementation in
+// src/components/selectedProjects/SelectedProjects.tsx.
+const CASES: Case[] = [
+  {
+    file: "src/components/hero/Hero.tsx",
+    description:
+      "Hero's full-bleed wrapper does not own the gutter (only the centered containers do)",
+    forbidden: `className="relative overflow-x-clip px-2 lg:mb-24 lg:px-0"`,
+    required: `className="relative overflow-x-clip lg:mb-24"`,
+  },
+  {
+    file: "src/components/hero/Hero.tsx",
+    description:
+      "Hero's primary centered container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="relative m-auto flex h-full max-w-6xl flex-col pt-12 md:mt-0 lg:flex-row"`,
+    required: `className="relative m-auto flex h-full max-w-6xl flex-col px-4 pt-12 sm:px-6 md:mt-0 lg:flex-row"`,
+  },
+  {
+    file: "src/components/hero/Hero.tsx",
+    description:
+      "Hero's metrics centered container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="relative m-auto max-w-6xl items-end justify-between lg:flex"`,
+    required: `className="relative m-auto max-w-6xl items-end justify-between px-4 sm:px-6 lg:flex"`,
+  },
+  {
+    file: "src/components/coreExpertise/CoreExpertise.tsx",
+    description:
+      "CoreExpertise container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="mx-auto max-w-6xl px-2 lg:px-0"`,
+    required: `className="mx-auto max-w-6xl px-4 sm:px-6"`,
+  },
+  {
+    file: "src/components/architectureShowcase/ArchitectureShowcase.tsx",
+    description:
+      "ArchitectureShowcase container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="mx-auto grid max-w-6xl gap-12 px-2 lg:grid-cols-2 lg:items-center lg:px-0"`,
+    required: `className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center"`,
+  },
+  {
+    file: "src/components/engineeringBeyondCode/EngineeringBeyondCode.tsx",
+    description:
+      "EngineeringBeyondCode container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="mx-auto grid max-w-6xl gap-12 px-2 lg:grid-cols-2 lg:items-center lg:px-0"`,
+    required: `className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center"`,
+  },
+  {
+    file: "src/components/technologies/Technologies.tsx",
+    description: "Technologies section does not carry its own gutter override",
+    forbidden: `className="relative lg:px-0"`,
+    required: `className="relative"`,
+  },
+  {
+    file: "src/components/technologies/Technologies.tsx",
+    description:
+      "Technologies inner container uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="relative m-auto flex h-full max-w-6xl flex-col gap-8 px-2 py-8 lg:gap-16 lg:px-0 lg:py-24"`,
+    required: `className="relative m-auto flex h-full max-w-6xl flex-col gap-8 px-4 py-8 sm:px-6 lg:gap-16 lg:py-24"`,
+  },
+  {
+    file: "src/components/finalCTA/FinalCTA.tsx",
+    description: "FinalCTA section uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="min-w-0 px-2 py-12 sm:px-0 lg:py-24"`,
+    required: `className="min-w-0 px-4 py-12 sm:px-6 lg:py-24"`,
+  },
+  {
+    file: "src/components/finalCTA/FinalCTA.tsx",
+    description:
+      "FinalCTA card matches the site's max-w-6xl primary container width",
+    forbidden: `className="mx-auto max-w-5xl min-w-0 rounded-lg border border-border bg-muted px-2 py-8 text-center text-foreground sm:p-12 lg:px-0"`,
+    required: `className="mx-auto max-w-6xl min-w-0 rounded-lg border border-border bg-muted p-6 text-center text-foreground sm:p-12"`,
+  },
+  {
+    file: "src/components/footer/Footer.tsx",
+    description: "Footer full-bleed wrapper does not own the gutter",
+    forbidden: `className="relative border-t bg-background px-2 py-8"`,
+    required: `className="relative border-t bg-background py-8"`,
+  },
+  {
+    file: "src/components/footer/Footer.tsx",
+    description: "Footer content row uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="relative mx-auto flex max-w-6xl flex-col-reverse items-center justify-between gap-8 lg:flex-row"`,
+    required: `className="relative mx-auto flex max-w-6xl flex-col-reverse items-center justify-between gap-8 px-4 sm:px-6 lg:flex-row"`,
+  },
+  {
+    file: "src/app/[locale]/about/page.tsx",
+    description: "About intro section uses the canonical px-4 sm:px-6 gutter",
+    forbidden: `className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[0.8fr_1.2fr]"`,
+    required: `className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.8fr_1.2fr]"`,
+  },
+  {
+    file: "src/app/[locale]/about/page.tsx",
+    description:
+      "About journey section matches the site's max-w-6xl primary container width",
+    forbidden: `className="mx-auto max-w-7xl px-6"`,
+    required: `className="mx-auto max-w-6xl px-4 sm:px-6"`,
+  },
+  {
+    file: "src/app/[locale]/contact/page.tsx",
+    description: "Contact main keeps its gutter at every breakpoint",
+    forbidden: `className="relative min-h-screen overflow-x-clip px-4 sm:px-6 lg:px-0"`,
+    required: `className="relative min-h-screen overflow-x-clip px-4 sm:px-6"`,
+  },
+]
+
+describe("layout gutter and width consistency (issue #48)", () => {
+  it.each(CASES)("$description", ({ file, forbidden, required }) => {
+    const source = readFileSync(join(process.cwd(), file), "utf-8")
+
+    expect(source).not.toContain(forbidden)
+    expect(source).toContain(required)
+  })
+})

--- a/tests/e2e/layout-consistency.spec.ts
+++ b/tests/e2e/layout-consistency.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test, type Page } from "@playwright/test"
+
+// Canonical rule (issue #48): a "canonical" container owns both the
+// `max-w-6xl` width and the `px-4 sm:px-6` gutter on the same element, and
+// sits directly inside an unpadded, full-width ancestor. That combination
+// means its computed max-width is always 1152px, its computed padding-left
+// is 16px below the `sm` breakpoint and 24px from `sm` upward, and it is
+// horizontally centered against the page's own clientWidth.
+const CANONICAL_ROUTES: { route: string; names: string[] }[] = [
+  {
+    route: "/en",
+    names: [
+      "hero-primary",
+      "hero-metrics",
+      "core-expertise",
+      "architecture-showcase",
+      "engineering-beyond-code",
+      "technologies",
+      "selected-projects",
+      "footer",
+    ],
+  },
+  { route: "/en/about", names: ["about-intro", "about-journey"] },
+  { route: "/en/articles", names: ["articles"] },
+]
+
+const narrowViewport = { width: 390, height: 844 } as const
+const desktopViewport = { width: 1440, height: 900 } as const
+const CANONICAL_MAX_WIDTH_PX = 1152
+const NARROW_GUTTER_PX = 16
+const WIDE_GUTTER_PX = 24
+
+type LayoutBox = {
+  maxWidth: string
+  paddingLeft: string
+  left: number
+  clientWidth: number
+}
+
+const readLayoutBox = (page: Page, name: string): Promise<LayoutBox | null> =>
+  page.evaluate((containerName) => {
+    const element = document.querySelector<HTMLElement>(
+      `[data-layout-container="${containerName}"]`
+    )
+    if (!element) return null
+
+    const style = getComputedStyle(element)
+    const rect = element.getBoundingClientRect()
+
+    return {
+      maxWidth: style.maxWidth,
+      paddingLeft: style.paddingLeft,
+      left: rect.left,
+      clientWidth: document.documentElement.clientWidth,
+    }
+  }, name)
+
+const expectCenteredAgainstViewport = (box: LayoutBox, maxWidthPx: number) => {
+  const expectedLeft = (box.clientWidth - maxWidthPx) / 2
+  expect(box.left).toBeCloseTo(expectedLeft, 0)
+}
+
+const overflowRoutes = [
+  "/en",
+  "/en/about",
+  "/en/articles",
+  "/en/contact",
+  "/ar",
+]
+
+test.describe("layout gutter and width consistency", () => {
+  for (const { route, names } of CANONICAL_ROUTES) {
+    test(`${route} canonical containers use a ${NARROW_GUTTER_PX}px gutter at ${narrowViewport.width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(narrowViewport)
+      await page.goto(route)
+
+      for (const name of names) {
+        const box = await readLayoutBox(page, name)
+        expect(box, `${name} should render`).not.toBeNull()
+        expect(box?.paddingLeft, `${name} padding-left`).toBe(
+          `${NARROW_GUTTER_PX}px`
+        )
+      }
+    })
+
+    test(`${route} canonical containers use a ${CANONICAL_MAX_WIDTH_PX}px max-width, ${WIDE_GUTTER_PX}px gutter, and a centered outer edge at ${desktopViewport.width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(desktopViewport)
+      await page.goto(route)
+
+      for (const name of names) {
+        const box = await readLayoutBox(page, name)
+        expect(box, `${name} should render`).not.toBeNull()
+        if (!box) continue
+
+        expect(box.maxWidth, `${name} max-width`).toBe(
+          `${CANONICAL_MAX_WIDTH_PX}px`
+        )
+        expect(box.paddingLeft, `${name} padding-left`).toBe(
+          `${WIDE_GUTTER_PX}px`
+        )
+        expectCenteredAgainstViewport(box, CANONICAL_MAX_WIDTH_PX)
+      }
+    })
+  }
+
+  test("FinalCTA card keeps the max-w-6xl width and centered outer edge as a card-padding exception", async ({
+    page,
+  }) => {
+    await page.setViewportSize(desktopViewport)
+    await page.goto("/en")
+
+    const box = await readLayoutBox(page, "final-cta")
+
+    expect(box).not.toBeNull()
+    if (!box) return
+
+    // The card itself intentionally does not own a `px-4 sm:px-6` gutter —
+    // its horizontal spacing comes from `p-6 sm:p-12` card padding while the
+    // section wraps it in the standard gutter. Only width and centering are
+    // asserted here, matching every other max-w-6xl primary container.
+    expect(box.maxWidth).toBe(`${CANONICAL_MAX_WIDTH_PX}px`)
+    expectCenteredAgainstViewport(box, CANONICAL_MAX_WIDTH_PX)
+  })
+
+  test("Contact keeps the standard page gutter without joining the max-w-6xl set", async ({
+    page,
+  }) => {
+    await page.setViewportSize(narrowViewport)
+    await page.goto("/en/contact")
+    const narrowBox = await readLayoutBox(page, "contact")
+    expect(narrowBox?.paddingLeft).toBe(`${NARROW_GUTTER_PX}px`)
+
+    await page.setViewportSize(desktopViewport)
+    await page.goto("/en/contact")
+    const wideBox = await readLayoutBox(page, "contact")
+    // Contact's max-w-3xl prose column is a documented width exception, so
+    // only the page-level gutter is asserted — not the max-w-6xl width.
+    expect(wideBox?.paddingLeft).toBe(`${WIDE_GUTTER_PX}px`)
+  })
+
+  for (const route of overflowRoutes) {
+    test(`${route} has no horizontal overflow at 320px`, async ({ page }) => {
+      await page.setViewportSize({ width: 320, height: 800 })
+      await page.goto(route)
+
+      const overflow = await page.evaluate(() => {
+        const root = document.documentElement
+        return {
+          scrollWidth: root.scrollWidth,
+          clientWidth: root.clientWidth,
+        }
+      })
+
+      expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1)
+    })
+
+    test(`${route} has no horizontal overflow at desktop and mobile viewports`, async ({
+      page,
+    }) => {
+      for (const viewport of [desktopViewport, { width: 390, height: 844 }]) {
+        await page.setViewportSize(viewport)
+        await page.goto(route)
+
+        const overflow = await page.evaluate(() => {
+          const root = document.documentElement
+          return {
+            scrollWidth: root.scrollWidth,
+            clientWidth: root.clientWidth,
+          }
+        })
+
+        expect(
+          overflow.scrollWidth,
+          `${route} at ${viewport.width}px`
+        ).toBeLessThanOrEqual(overflow.clientWidth + 1)
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- standardize public section gutters on `px-4 sm:px-6`
- align primary containers to `max-w-6xl`
- move gutters from full-bleed wrappers to their centered content containers
- add focused Vitest and Playwright regression coverage for computed gutters, widths, mobile overflow, and RTL

## Intentional width/layout exceptions

- article detail remains `max-w-4xl` for prose readability
- contact content remains `max-w-3xl` for form readability while its page shell keeps canonical gutters
- FinalCTA keeps card-specific `p-6 sm:p-12` internal padding while its outer width is standardized to `max-w-6xl`
- fixed floating navigation and intentional full-bleed backgrounds/borders are unchanged
- inner `max-w-2xl` and `max-w-3xl` copy blocks remain readability constraints rather than primary page containers

## Validation

- `pnpm check`
  - formatting, ESLint, dead-code detection, TypeScript, content validation, and production build passed
  - 206/206 Vitest tests passed, including 15 focused layout source-contract tests
- focused layout Playwright: 36/36 passed across desktop and mobile projects
- full Playwright suite: 195 passed, 1 intentionally skipped
- `git show --check`: passed
- added-line secret/unsafe-pattern scan: no findings

Closes #48
