### PR TITLE
fix: align shared control focus and target sizes

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-foreground focus-visible:ring-3 focus-visible:ring-foreground active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:focus-visible:ring-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -17,15 +17,15 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive focus-visible:ring-destructive dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-11 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        lg: "h-11 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-8",
         "icon-xs":
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-11 w-full min-w-0 rounded-lg border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-11 w-full min-w-0 rounded-lg border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:ring-3 focus-visible:ring-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:focus-visible:ring-destructive md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:focus-visible:ring-destructive",
         className
       )}
       {...props}

--- a/src/styles/focus-and-target-size.test.ts
+++ b/src/styles/focus-and-target-size.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const globalsCss = readFileSync(join(__dirname, "globals.css"), "utf-8")
+const buttonSource = readFileSync(
+  join(__dirname, "../components/ui/button.tsx"),
+  "utf-8"
+)
+const inputSource = readFileSync(
+  join(__dirname, "../components/ui/input.tsx"),
+  "utf-8"
+)
+
+describe("shared focus-visible contract", () => {
+  it("suppresses the global outline on the button data-slot so only the component ring shows", () => {
+    expect(globalsCss).toMatch(
+      /\[data-slot=(["']?)button\1\]:focus-visible[\s\S]{0,120}?{[^}]*outline:\s*none/
+    )
+  })
+
+  it("also suppresses the global outline when buttonVariants styles a link", () => {
+    expect(globalsCss).toMatch(
+      /\[class~=(["'])group\/button\1\]:focus-visible[\s\S]{0,120}?outline:\s*none/
+    )
+  })
+
+  it("suppresses the global outline on the input data-slot so only the component ring shows", () => {
+    expect(globalsCss).toMatch(
+      /\[data-slot=(["']?)input\1\]:focus-visible[\s\S]{0,120}?{[^}]*outline:\s*none/
+    )
+  })
+
+  it("still defines a single high-contrast global outline rule for elements without their own ring", () => {
+    expect(globalsCss).toMatch(
+      /:focus-visible\s*{\s*outline:\s*2px solid var\(--foreground\)/
+    )
+  })
+
+  it("uses opaque foreground focus rings for shared Button and Input controls", () => {
+    expect(buttonSource).toMatch(/focus-visible:ring-foreground/)
+    expect(inputSource).toMatch(/focus-visible:ring-foreground/)
+    expect(buttonSource).not.toMatch(/focus-visible:ring-ring\/50/)
+    expect(inputSource).not.toMatch(/focus-visible:ring-ring\/50/)
+  })
+})
+
+describe("Button target size", () => {
+  const sizeBlockMatch = buttonSource.match(/size:\s*{([\s\S]*?)},\n\s*},/)
+  const sizeBlock = sizeBlockMatch?.[1] ?? ""
+
+  it("gives the default size an at-least-44px (h-11) height", () => {
+    const defaultSizeMatch = sizeBlock.match(/default:\s*\n?\s*"([^"]*)"/)
+    expect(defaultSizeMatch).not.toBeNull()
+    expect(defaultSizeMatch?.[1]).toMatch(/(?:^|\s)h-11(?:\s|$)/)
+  })
+
+  it("gives the lg size an at-least-44px (h-11) height", () => {
+    const lgSizeMatch = buttonSource.match(/lg:\s*"([^"]*)"/)
+    expect(lgSizeMatch).not.toBeNull()
+    expect(lgSizeMatch?.[1]).toMatch(/(?:^|\s)h-11(?:\s|$)/)
+  })
+
+  it("keeps the xs compact opt-in smaller than 44px", () => {
+    const xsSizeMatch = buttonSource.match(/xs:\s*"([^"]*)"/)
+    expect(xsSizeMatch?.[1]).toMatch(/(?:^|\s)h-6(?:\s|$)/)
+  })
+
+  it("keeps the sm compact opt-in smaller than 44px", () => {
+    const smSizeMatch = buttonSource.match(/sm:\s*"([^"]*)"/)
+    expect(smSizeMatch?.[1]).toMatch(/(?:^|\s)h-7(?:\s|$)/)
+  })
+
+  it("keeps the compact icon-xs and icon-sm opt-ins smaller than 44px", () => {
+    const iconXsMatch = buttonSource.match(/"icon-xs":\s*"([^"]*)"/)
+    const iconSmMatch = buttonSource.match(/"icon-sm":\s*"([^"]*)"/)
+    expect(iconXsMatch?.[1]).toMatch(/(?:^|\s)size-6(?:\s|$)/)
+    expect(iconSmMatch?.[1]).toMatch(/(?:^|\s)size-7(?:\s|$)/)
+  })
+
+  it("leaves the ordinary navbar icon sizes unchanged since their fixed-height navbar is out of scope", () => {
+    const iconMatch = sizeBlock.match(/icon:\s*"([^"]*)"/)
+    const iconLgMatch = sizeBlock.match(/"icon-lg":\s*"([^"]*)"/)
+    expect(iconMatch?.[1]).toMatch(/(?:^|\s)size-8(?:\s|$)/)
+    expect(iconLgMatch?.[1]).toMatch(/(?:^|\s)size-9(?:\s|$)/)
+  })
+})
+
+describe("Input/Button height alignment", () => {
+  it("keeps the shared Input control at h-11 (44px)", () => {
+    expect(inputSource).toMatch(/["\s]h-11(?:\s|")/)
+  })
+})
+
+describe("disabled state contract", () => {
+  it("keeps Button non-interactive and dimmed when disabled", () => {
+    expect(buttonSource).toMatch(/disabled:pointer-events-none/)
+    expect(buttonSource).toMatch(/disabled:opacity-50/)
+  })
+
+  it("keeps Input non-interactive and dimmed when disabled", () => {
+    expect(inputSource).toMatch(/disabled:pointer-events-none/)
+    expect(inputSource).toMatch(/disabled:cursor-not-allowed/)
+    expect(inputSource).toMatch(/disabled:opacity-50/)
+  })
+})

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -183,8 +183,19 @@
   }
 
   :focus-visible {
-    outline: 2px solid var(--ring);
+    outline: 2px solid var(--foreground);
     outline-offset: 3px;
+  }
+
+  /*
+   * Shared controls (Button, Input) render their own opaque foreground focus
+   * ring. Suppress the global outline for those controls and links styled with
+   * buttonVariants so keyboard focus shows exactly one high-contrast indicator.
+   */
+  [data-slot="button"]:focus-visible,
+  [class~="group/button"]:focus-visible,
+  [data-slot="input"]:focus-visible {
+    outline: none;
   }
 }
 

--- a/tests/e2e/focus-and-target-size.spec.ts
+++ b/tests/e2e/focus-and-target-size.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Shared Button/Input focus indicator and target size", () => {
+  test("homepage contact dialog trigger, Input, and submit all reach at least 44px", async ({
+    page,
+  }) => {
+    await page.goto("/en")
+
+    const trigger = page.locator('button[aria-haspopup="dialog"]').last()
+    const triggerBox = await trigger.boundingBox()
+    expect(triggerBox?.height ?? 0).toBeGreaterThanOrEqual(44)
+
+    await trigger.click()
+
+    const nameInput = page.locator("#contact-name")
+    await expect(nameInput).toBeVisible()
+    const inputBox = await nameInput.boundingBox()
+    expect(inputBox?.height ?? 0).toBeGreaterThanOrEqual(44)
+
+    const submit = page
+      .locator("#contact-form")
+      .locator('button[type="submit"]')
+    const submitBox = await submit.boundingBox()
+    expect(submitBox?.height ?? 0).toBeGreaterThanOrEqual(44)
+  })
+
+  test("Input and submit show exactly one focus indicator, not an outline stacked on the ring", async ({
+    page,
+  }) => {
+    await page.goto("/en/contact")
+
+    const nameInput = page.locator("#contact-name")
+    await nameInput.focus()
+    await expect(nameInput).toBeFocused()
+
+    const inputFocusStyle = await nameInput.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return { outlineStyle: style.outlineStyle, boxShadow: style.boxShadow }
+    })
+    expect(inputFocusStyle.outlineStyle).toBe("none")
+    expect(inputFocusStyle.boxShadow).not.toBe("none")
+
+    const submit = page.getByRole("button", { name: /send/i })
+    await submit.focus()
+    await expect(submit).toBeFocused()
+
+    const buttonFocusStyle = await submit.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return { outlineStyle: style.outlineStyle, boxShadow: style.boxShadow }
+    })
+    expect(buttonFocusStyle.outlineStyle).toBe("none")
+    expect(buttonFocusStyle.boxShadow).not.toBe("none")
+  })
+
+  test("empty submission marks the Input invalid with a visibly different border", async ({
+    page,
+  }) => {
+    await page.goto("/en/contact")
+
+    const nameInput = page.locator("#contact-name")
+    const borderColorBefore = await nameInput.evaluate(
+      (el) => getComputedStyle(el).borderColor
+    )
+
+    await page.getByRole("button", { name: /send/i }).click()
+
+    await expect(nameInput).toHaveAttribute("aria-invalid", "true")
+    const borderColorAfter = await nameInput.evaluate(
+      (el) => getComputedStyle(el).borderColor
+    )
+    expect(borderColorAfter).not.toBe(borderColorBefore)
+  })
+
+  test("a generic footer link keeps the shared global outline on keyboard focus", async ({
+    page,
+  }) => {
+    await page.goto("/en")
+
+    const brandLink = page
+      .locator("footer")
+      .getByRole("link", { name: "Go to homepage" })
+    await brandLink.focus()
+    await expect(brandLink).toBeFocused()
+
+    const linkFocusStyle = await brandLink.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return {
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+      }
+    })
+    expect(linkFocusStyle.outlineStyle).toBe("solid")
+    expect(linkFocusStyle.outlineWidth).toBe("2px")
+  })
+
+  test("a link styled with buttonVariants uses its ring without the global outline", async ({
+    page,
+  }) => {
+    await page.goto("/en")
+
+    const styledLink = page.locator("footer nav a").first()
+    await styledLink.focus()
+    await expect(styledLink).toBeFocused()
+
+    const focusStyle = await styledLink.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return { outlineStyle: style.outlineStyle, boxShadow: style.boxShadow }
+    })
+    expect(focusStyle.outlineStyle).toBe("none")
+    expect(focusStyle.boxShadow).not.toBe("none")
+  })
+})


### PR DESCRIPTION
## Summary

- make default and large shared Button variants 44px high to align with Input and form-submit targets
- preserve explicit compact button/icon variants and existing navbar icon sizing
- keep the global high-contrast foreground outline for generic interactive elements while suppressing it for Button/Input data slots and `buttonVariants` consumers that render their own opaque foreground focus ring
- add source-contract and browser regression coverage for target sizes, single focus indicators, invalid state, disabled-state classes, and generic-link focus

## Validation

- strict TDD RED: focused source-contract assertions failed against the original `h-8`/`h-9` sizes and missing Button/Input outline-suppression contract
- focused Vitest GREEN: 14/14 passed
- focused Playwright: 10/10 passed across desktop and mobile Chromium
- related contact/dialog/hero/navigation Playwright regression set: 68/68 passed
- `pnpm check`: passed
  - formatting, ESLint, dead-code detection, TypeScript, 220/220 Vitest tests, localized content validation, and production build
- `git diff --check`: passed

Closes #49
