### PR TITLE
fix: add accessible footer email link

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/i18n/routing"
+import { Mail } from "lucide-react"
 import { useTranslations } from "next-intl"
 
 import Logo from "@/components/navbar/Logo"
@@ -9,7 +10,6 @@ import GridBackground from "@/components/ui/GridBackground"
 import { navigationConfig } from "@/lib/config/navigation"
 import { siteConfig } from "@/lib/config/site"
 import { cn } from "@/lib/utils"
-import { Mail } from "lucide-react"
 
 export default function Footer() {
   const t = useTranslations()
@@ -48,12 +48,17 @@ export default function Footer() {
           </div>
 
           <div className="mt-2 text-center text-sm text-muted-foreground md:text-start">
-            <p>{copyright}</p>
-
-            <p className="flex items-center justify-center gap-2 md:justify-start">
-              <Mail />
-              info@ghassan.de
+            <p>
+              <a
+                href="mailto:info@ghassan.de"
+                className="inline-flex items-center justify-center gap-2 rounded-sm focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:outline-none md:justify-start"
+              >
+                <Mail aria-hidden="true" className="size-4 shrink-0" />
+                <span>info@ghassan.de</span>
+              </a>
             </p>
+
+            <p>{copyright}</p>
           </div>
         </div>
 

--- a/tests/e2e/footer.spec.ts
+++ b/tests/e2e/footer.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("Footer contact link", () => {
+  test("renders the email as the first metadata row with a decorative icon", async ({
+    page,
+  }) => {
+    await page.goto("/en")
+
+    const metadataRows = page.locator("footer p")
+    const contactRow = metadataRows.first()
+    const emailLink = contactRow.getByRole("link", {
+      name: "info@ghassan.de",
+    })
+
+    await expect(emailLink).toHaveAttribute("href", "mailto:info@ghassan.de")
+    await expect(emailLink.locator('svg[aria-hidden="true"]')).toHaveCount(1)
+    await expect(contactRow).toContainText("info@ghassan.de")
+    await expect(metadataRows.nth(1)).toContainText("©")
+  })
+
+  test("keeps responsive alignment and shows a clear focus indicator", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/en")
+
+    const emailLink = page
+      .locator("footer")
+      .getByRole("link", { name: "info@ghassan.de" })
+    await emailLink.focus()
+    await expect(emailLink).toBeFocused()
+
+    const styles = await emailLink.evaluate((element) => {
+      const style = getComputedStyle(element)
+      return {
+        boxShadow: style.boxShadow,
+        justifyContent: style.justifyContent,
+        outlineStyle: style.outlineStyle,
+      }
+    })
+
+    expect(styles.outlineStyle).toBe("none")
+    expect(styles.boxShadow).not.toBe("none")
+    expect(styles.justifyContent).toBe(
+      testInfo.project.name === "mobile-chromium" ? "center" : "flex-start"
+    )
+  })
+})


### PR DESCRIPTION
## Summary

* Turn the footer email address into a working `mailto:` link
* Place the contact row before the copyright row
* Add a decorative mail icon, responsive alignment, and a visible keyboard focus ring
* Add focused desktop and mobile Chromium coverage

## Verification

* Red test: footer link test failed before implementation as expected, 4 failures
* Green test: `pnpm exec playwright test tests/e2e/footer.spec.ts --project=desktop-chromium --project=mobile-chromium`, 4 passed in 12.9s
* `pnpm check`, passed: formatting, ESLint with zero warnings, Knip, TypeScript, 25 Vitest files with 220 tests, multilingual content validation, and production build
* `git diff --check`, passed

## Agent provenance

* Multica issue: GHA-7
* Agent: Codex Builder
* Model exposed by Multica: GPT-5
* Input tokens: unavailable
* Output tokens: unavailable
* Total tokens: unavailable

Closes #51